### PR TITLE
FeatureAdded: get_rel_coord() method added

### DIFF
--- a/src/framat/_meshing.py
+++ b/src/framat/_meshing.py
@@ -446,6 +446,13 @@ class AbstractBeamMesh:
                 z_min = z_minb
         return (x_min, x_max), (y_min, y_max), (z_min, z_max)
 
+    def get_rel_coord(self, beam_idx):
+        """Return an array (n, ) with all node relative span position"""
+        beam = self.beams[beam_idx]
+        coords = [beam[0].p1.rel_coord]  # Start with first node
+        coords += [elem.p2.rel_coord for elem in beam.values()]
+        return np.array(coords)
+
     def gnv(self, vector, uid):
         """
         Return the nodal value from a given vector (e.g. displacement or load)


### PR DESCRIPTION
Closes #3 

The original issue suggested a more complex solution — adding the relative span position as an input to each node — but after digging into it, it turns out that’s not really needed. We can just return the `rel_coord` value that’s already being computed for each `Point` inside `framat`.

This keeps things simpler and still does the job: `rel_coord` gives us the normalized position along the span, which is exactly what the issue was aiming for anyway.
